### PR TITLE
Fix a bug where controller glyphID's are wrong on many gamepads.

### DIFF
--- a/Runtime/GlyphUtility.cs
+++ b/Runtime/GlyphUtility.cs
@@ -63,7 +63,7 @@ namespace Valax321.ControllerPrompts
                     break;
                 default:
                     var template = controller.Templates.First();
-                    glyphID = template.GetElement(action.elementIndex).id;
+                    glyphID = template.GetElement(action.elementIdentifierId).id;
                     break;
             }
 


### PR DESCRIPTION
It seems like when using `template.GetElement()`, `action.elementIdentifierId` should be used, rather than `action.elementIndex`.

From the [Rewired How-Tos](https://guavaman.com/projects/rewired/docs/HowTos.html#display-glyph-for-action):

>Here are the basic steps:
>1. Get the last used Controller from the Player using `Player.controllers.GetLastActiveController`.
>2. Determine the type of the Controller using the `Controller.type property`.
>3. If a Joystick, identify this Joystick as a recognized type using the `Joystick.hardwareTypeGuid` property. (The type GUID for each recognized Controller can be found in this CSV file.)
>4. Check if any element on this Controller is mapped to the Action in question using one of the following methods:
    `Player.controllers.maps.GetFirstElementMapWithAction`
    `Player.controllers.maps.GetFirstButtonMapWithAction`
    `Player.controllers.maps.GetFirstAxisMapWithAction`
    `Player.controllers.maps.ElementMapsWithAction`
    `Player.controllers.maps.ButtonMapsWithAction`
    `Player.controllers.maps.AxisMapsWithAction`
>5. If the element is mapped, use this information to look up the glyph from your lookup table using the **`ActionElementMap.elementIdentifierId`** property and the `Joystick.hardwareTypeGuid` property.
>6. Optional: Further information about the mapping can be found in the `ActionElementMap` such as the Axis Range, Axis Contribution, type, or other useful information should you need more specific glyphs for a finer level of detail.

I'll admit I'm not really sure what `action.elementIndex` even does, so I'm sorry if this patch is misplaced.  It did fix a bug for me though.

Also it looks like the GitHub editor decided to do something to the newline on `78`, sorry about that.